### PR TITLE
fix: enable parsing markdown content in a file

### DIFF
--- a/xform-to-enketo/server.js
+++ b/xform-to-enketo/server.js
@@ -49,7 +49,7 @@ async function convertForm(xform) {
   return transform({
     xform: xform,
     theme: "grid",
-    markdown: false,
+    markdown: true,
     preprocess: (doc) => doc,
   });
 }


### PR DESCRIPTION
### What this PR does?

This enables parsing of markdown content on in the xml uploaded to the ```xform-to-enketo``` tool

### Related issue

Closes: #302 
Closes: https://github.com/e-picsa/picsa-apps/issues/302

### Previous Frontend issue
![image](https://github.com/user-attachments/assets/de02e5df-3b42-4a1c-b9fe-c51ce12c256e)

### Final outcome on the frontend
<img width="1470" alt="Screenshot 2024-07-29 at 11 56 59" src="https://github.com/user-attachments/assets/d304a278-fc52-4a07-932b-9c49d8568cad">


